### PR TITLE
Fixed Movement bug

### DIFF
--- a/game/Scripts/Actors/Player/PlayerStates/move.gd
+++ b/game/Scripts/Actors/Player/PlayerStates/move.gd
@@ -15,6 +15,8 @@ extends State
 func enter() -> void:
 	super.enter()
 	print("DEBUG/MOVE: Player Entered the move state")
+	if parent.is_on_floor():
+		move_stats.jumps_used = 0
 	# player can only enter this state on the ground then we should reset the jumps
 	
 func exit() -> void:


### PR DESCRIPTION
In the case where the player went directly from falling to moving on the ground no idle state would be entered thus jumps were not available the next time the player would jump
 