### PR TITLE
fixed error where player would be null when trying to set its ref

### DIFF
--- a/game/Scenes/Levels/level_01.tscn
+++ b/game/Scenes/Levels/level_01.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=4 uid="uid://3p516xh7bwo4"]
+[gd_scene load_steps=15 format=4 uid="uid://3p516xh7bwo4"]
 
 [ext_resource type="PackedScene" uid="uid://dj33b6ynfouwy" path="res://Scenes/Level_Template.tscn" id="1_yavgd"]
 [ext_resource type="PackedScene" uid="uid://biuxaol52s4r8" path="res://Scripts/Objects/Buttons/PressurePlates/BluePressurePlate/BluePressurePlate.tscn" id="2_gt7c3"]
@@ -8,6 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://36pkp13b1yer" path="res://Scripts/Objects/Platforms/Oneway/OneWayPlatform.tscn" id="8_mqiev"]
 [ext_resource type="Script" path="res://Scripts/Components/Movement/move_stats.gd" id="9_6l6bg"]
 [ext_resource type="PackedScene" uid="uid://bgcbd2ho8pv1d" path="res://Scripts/Objects/Buttons/Pedestals/RedPedestal/RedPedestal.tscn" id="9_6wy4a"]
+[ext_resource type="PackedScene" uid="uid://b5awsjbb8w6pi" path="res://Scripts/Objects/ThrowableObjects/ThrowableObject.tscn" id="9_rlg5w"]
 
 [sub_resource type="Resource" id="Resource_ucykb"]
 resource_local_to_scene = true
@@ -42,7 +43,7 @@ dash_distance = 100.0
 polygon = PackedVector2Array(848, 192, 880, 192, 864, 208)
 
 [sub_resource type="OccluderPolygon2D" id="OccluderPolygon2D_l4j7q"]
-polygon = PackedVector2Array(1024, 128, 1056, 128, 1040, 144)
+polygon = PackedVector2Array(848, 128, 880, 128, 864, 144)
 
 [sub_resource type="OccluderPolygon2D" id="OccluderPolygon2D_0sl3x"]
 polygon = PackedVector2Array(1152, 144, 1168, 144, 1168, 128, 1152, 128)
@@ -120,3 +121,9 @@ position = Vector2(512, 262)
 
 [node name="PauseMenu" parent="." index="13"]
 visible = false
+
+[node name="BackgroundMusic" parent="." index="14"]
+visible = false
+
+[node name="ThrowableObject" parent="." index="15" instance=ExtResource("9_rlg5w")]
+position = Vector2(248, 318)

--- a/game/Scenes/test_level.tscn
+++ b/game/Scenes/test_level.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=7 format=4 uid="uid://cnvqs74bujyhb"]
+[gd_scene load_steps=8 format=4 uid="uid://cnvqs74bujyhb"]
 
 [ext_resource type="PackedScene" uid="uid://dj33b6ynfouwy" path="res://Scenes/Level_Template.tscn" id="1_el2di"]
 [ext_resource type="PackedScene" uid="uid://36pkp13b1yer" path="res://Scripts/Objects/Platforms/Oneway/OneWayPlatform.tscn" id="2_xnktr"]
 [ext_resource type="PackedScene" uid="uid://b5awsjbb8w6pi" path="res://Scripts/Objects/ThrowableObjects/ThrowableObject.tscn" id="3_l8gwj"]
 [ext_resource type="PackedScene" uid="uid://bbnivbfgvtu3c" path="res://Scripts/Actors/Enemy/Enemy.tscn" id="4_j1gdk"]
 [ext_resource type="Script" path="res://Scripts/Components/Movement/move_stats.gd" id="5_81st2"]
+[ext_resource type="PackedScene" uid="uid://dveonqmfkatdx" path="res://Scripts/Objects/MovableSquare/MovableSquare.tscn" id="6_d5meh"]
 
 [sub_resource type="Resource" id="Resource_fh7g2"]
 resource_local_to_scene = true
@@ -78,6 +79,14 @@ position = Vector2(272, 248)
 [node name="Enemy" parent="." index="14" instance=ExtResource("4_j1gdk")]
 position = Vector2(912, 48)
 movement = SubResource("Resource_fh7g2")
+
+[node name="MovableSquare" parent="." index="15" instance=ExtResource("6_d5meh")]
+position = Vector2(768, 256)
+acceleration = null
+push_force = null
+max_push_force = null
+friction = null
+gravity_scale = null
 
 [editable path="ThrowableObject"]
 [editable path="ThrowableObject/HitBox"]

--- a/game/Scripts/Actors/Player/player.gd
+++ b/game/Scripts/Actors/Player/player.gd
@@ -49,12 +49,12 @@ func _physics_process(delta: float) -> void:
 	state_controller.process_physics(delta)
 	sprite.flip_h = dir < 0
 
-	# #Uncomment to enable pushing ridged bodys
-	# for i in get_slide_collision_count():
-	# 	var c = get_slide_collision(i)
-	# 	if c.get_collider() is RigidBody2D and c.get_collider().has_method("apply_central_impulse"):
-	# 		var push_force = (PUSH_FORCE * velocity.length() / movement_stats.get_speed(self)) + MIN_PUSH_FORCE
-	# 		c.get_collider().apply_central_impulse(-c.get_normal() * push_force)
+	#Uncomment to enable pushing ridged bodys
+	for i in get_slide_collision_count():
+		var c = get_slide_collision(i)
+		if c.get_collider() is RigidBody2D and c.get_collider().has_method("apply_central_impulse"):
+			var push_force = (PUSH_FORCE * velocity.length() / movement_stats.get_speed(self)) + MIN_PUSH_FORCE
+			c.get_collider().apply_central_impulse(-c.get_normal() * push_force)
 
 	
 
@@ -100,6 +100,7 @@ func _on_hitbox_entered(caller : Node2D, body : Node2D) -> void:
 		if caller is Throwable:
 			throwable_in_range = true
 			caller.in_range = true
+			caller.player = self
 			Debug.debug(self, "Player Entered the hitbox of the throwable %s" % caller.in_range, false)
 				
 

--- a/game/Scripts/Objects/ThrowableObjects/ThrowableObject.gd
+++ b/game/Scripts/Objects/ThrowableObjects/ThrowableObject.gd
@@ -11,14 +11,12 @@ var in_range : bool = false
 func _ready():
 	Validate.check_reference(self, "hitbox", "HitBox")
 	Validate.check_reference(self, "collision", "CollisionShape2D")
-
-	player = get_tree().get_first_node_in_group("Player")
-	assert(player != null, "player is null")
-
 	hitbox.init(self)
+	
 
-# looks at the players input to see if they want to interact or throw
+## looks at the players input to see if they want to interact or throw
 func _input(event : InputEvent):
+	if !player: return # if no player is set do not look for input
 	if player.input.get_interact():
 		if !is_picked_up and in_range:
 			pickup()
@@ -65,6 +63,9 @@ func drop():
 	await get_tree().process_frame
 	self.freeze = false
 
+func _process(delta: float) -> void:
+	if !in_range and !is_picked_up:
+		player = null
 	
 # Handles resetting the flags on throw
 # Places object back in tree and applies a force to it.


### PR DESCRIPTION
These are the fixes i was mentioning for the throwable object.
Allows the ball to be pushed.
Sets the players ref when the player collides with the ball and set the ref to null when the player is not in range and the item is not picked up